### PR TITLE
Fix/31374 barros 3

### DIFF
--- a/src/components/MemberInviteList.js
+++ b/src/components/MemberInviteList.js
@@ -47,6 +47,7 @@ const defaultProps = {
     excludedUsers: [],
     name: '',
     shouldShowAlertPrompt: false,
+    showLoadingPlaceholder: false,
 };
 
 function MemberInviteList(props) {
@@ -179,7 +180,7 @@ function MemberInviteList(props) {
                 onConfirm={() => inviteUsers(selectedOptions)}
                 showScrollIndicator
                 shouldPreventDefaultFocusOnSelectRow={!Browser.isMobile()}
-                showLoadingPlaceholder={showLoadingPlaceholder || !OptionsListUtils.isPersonalDetailsReady(personalDetails)}
+                showLoadingPlaceholder={showLoadingPlaceholder || !OptionsListUtils.isPersonalDetailsReady(props.personalDetails)}
             />
             <View style={[styles.flexShrink0]}>
                 <FormAlertWithSubmitButton

--- a/src/components/MemberInviteList.js
+++ b/src/components/MemberInviteList.js
@@ -21,9 +21,6 @@ const propTypes = {
     /** All of the personal details for everyone */
     personalDetails: PropTypes.objectOf(personalDetailsPropType),
 
-    /** To indicate that the screen transaction has ended */
-    didScreenTransitionEnd: PropTypes.bool.isRequired,
-
     /** The users are not eligible for invitation */
     excludedUsers: PropTypes.arrayOf(PropTypes.string),
 
@@ -49,7 +46,7 @@ const defaultProps = {
 };
 
 function MemberInviteList(props) {
-    const {excludedUsers, betas, didScreenTransitionEnd, name, inviteUsers, shouldShowAlertPrompt, confirmButtonText} = props;
+    const {excludedUsers, betas, name, inviteUsers, shouldShowAlertPrompt, confirmButtonText} = props;
     const {translate} = useLocalize();
     const [selectedOptions, setSelectedOptions] = useState([]);
     const [personalDetails, setPersonalDetails] = useState([]);
@@ -97,7 +94,7 @@ function MemberInviteList(props) {
         return sections;
     };
 
-    const sections = didScreenTransitionEnd ? getSections() : [];
+    const sections = getSections();
 
     useEffect(() => {
         setSearchTerm(SearchInputManager.searchInput);
@@ -160,7 +157,7 @@ function MemberInviteList(props) {
                 onConfirm={() => inviteUsers(selectedOptions)}
                 showScrollIndicator
                 shouldPreventDefaultFocusOnSelectRow={!Browser.isMobile()}
-                showLoadingPlaceholder={!didScreenTransitionEnd || !OptionsListUtils.isPersonalDetailsReady(personalDetails)}
+                showLoadingPlaceholder={!OptionsListUtils.isPersonalDetailsReady(personalDetails)}
             />
             <View style={[styles.flexShrink0]}>
                 <FormAlertWithSubmitButton

--- a/src/components/MemberInviteList.js
+++ b/src/components/MemberInviteList.js
@@ -36,6 +36,9 @@ const propTypes = {
 
     /** Whether to show the alert text */
     shouldShowAlertPrompt: PropTypes.bool,
+
+    /** Whether to force loading placeholder */
+    showLoadingPlaceholder: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -47,7 +50,7 @@ const defaultProps = {
 };
 
 function MemberInviteList(props) {
-    const {excludedUsers, betas, name, shouldShowAlertPrompt, confirmButtonText} = props;
+    const {excludedUsers, betas, name, shouldShowAlertPrompt, confirmButtonText, showLoadingPlaceholder} = props;
     const {translate} = useLocalize();
     const [selectedOptions, setSelectedOptions] = useState([]);
     const [personalDetails, setPersonalDetails] = useState([]);
@@ -95,7 +98,7 @@ function MemberInviteList(props) {
         return sections;
     };
 
-    const sections = getSections();
+    const sections = showLoadingPlaceholder ? [] : getSections();
 
     useEffect(() => {
         setSearchTerm(SearchInputManager.searchInput);
@@ -176,7 +179,7 @@ function MemberInviteList(props) {
                 onConfirm={() => inviteUsers(selectedOptions)}
                 showScrollIndicator
                 shouldPreventDefaultFocusOnSelectRow={!Browser.isMobile()}
-                showLoadingPlaceholder={!OptionsListUtils.isPersonalDetailsReady(personalDetails)}
+                showLoadingPlaceholder={showLoadingPlaceholder || !OptionsListUtils.isPersonalDetailsReady(personalDetails)}
             />
             <View style={[styles.flexShrink0]}>
                 <FormAlertWithSubmitButton

--- a/src/components/MemberInviteList.js
+++ b/src/components/MemberInviteList.js
@@ -1,3 +1,4 @@
+import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {View} from 'react-native';
@@ -46,7 +47,7 @@ const defaultProps = {
 };
 
 function MemberInviteList(props) {
-    const {excludedUsers, betas, name, inviteUsers, shouldShowAlertPrompt, confirmButtonText} = props;
+    const {excludedUsers, betas, name, shouldShowAlertPrompt, confirmButtonText} = props;
     const {translate} = useLocalize();
     const [selectedOptions, setSelectedOptions] = useState([]);
     const [personalDetails, setPersonalDetails] = useState([]);
@@ -143,6 +144,24 @@ function MemberInviteList(props) {
         }
         return OptionsListUtils.getHeaderMessage(personalDetails.length !== 0, Boolean(userToInvite), searchValue);
     }, [excludedUsers, translate, searchTerm, userToInvite, personalDetails.length, name]);
+
+    const inviteUsers = (selectedUsers) => {
+        if (selectedUsers.length <= 0) {
+            return;
+        }
+
+        const selectedEmailsToAccountIDs = {};
+        _.each(selectedUsers, (option) => {
+            const login = option.login || '';
+            const accountID = lodashGet(option, 'accountID', '');
+            if (!login.toLowerCase().trim() || !accountID) {
+                return;
+            }
+            selectedEmailsToAccountIDs[login] = Number(accountID);
+        });
+
+        props.inviteUsers(selectedEmailsToAccountIDs);
+    };
 
     return (
         <>

--- a/src/pages/RoomInvitePage.js
+++ b/src/pages/RoomInvitePage.js
@@ -52,15 +52,6 @@ const defaultProps = {
 function RoomInvitePage(props) {
     const {translate} = useLocalize();
 
-    const validate = useCallback((selectedUsersSize) => {
-        const errors = {};
-        if (selectedUsersSize <= 0) {
-            errors.noUserSelected = true;
-        }
-
-        return _.size(errors) <= 0;
-    }, []);
-
     // Non policy members should not be able to view the participants of a room
     const reportID = props.report.reportID;
     const isPolicyMember = useMemo(() => PolicyUtils.isPolicyMember(props.report.policyID, props.policies), [props.report.policyID, props.policies]);
@@ -77,23 +68,11 @@ function RoomInvitePage(props) {
     );
 
     const inviteUsers = useCallback(
-        (selectedUsers) => {
-            if (!validate()) {
-                return;
-            }
-            const invitedEmailsToAccountIDs = {};
-            _.each(selectedUsers, (option) => {
-                const login = option.login || '';
-                const accountID = lodashGet(option, 'accountID', '');
-                if (!login.toLowerCase().trim() || !accountID) {
-                    return;
-                }
-                invitedEmailsToAccountIDs[login] = Number(accountID);
-            });
-            Report.inviteToRoom(props.report.reportID, invitedEmailsToAccountIDs);
+        (selectedEmailsToAccountIDs) => {
+            Report.inviteToRoom(props.report.reportID, selectedEmailsToAccountIDs);
             Navigation.navigate(backRoute);
         },
-        [backRoute, props.report.reportID, validate],
+        [backRoute, props.report.reportID],
     );
 
     return (

--- a/src/pages/RoomInvitePage.js
+++ b/src/pages/RoomInvitePage.js
@@ -9,7 +9,6 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MemberInviteList from '@components/MemberInviteList';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
-import useThemeStyles from '@hooks/useThemeStyles';
 import compose from '@libs/compose';
 import Navigation from '@libs/Navigation/Navigation';
 import * as OptionsListUtils from '@libs/OptionsListUtils';
@@ -51,7 +50,6 @@ const defaultProps = {
 };
 
 function RoomInvitePage(props) {
-    const styles = useThemeStyles();
     const {translate} = useLocalize();
 
     const validate = useCallback((selectedUsersSize) => {
@@ -116,16 +114,14 @@ function RoomInvitePage(props) {
                             Navigation.goBack(backRoute);
                         }}
                     />
-                    <View style={[styles.flex1]}>
-                        {didScreenTransitionEnd && (
-                            <MemberInviteList
-                                inviteUsers={inviteUsers}
-                                excludedUsers={excludedUsers}
-                                name={reportName}
-                                confirmButtonText={translate('common.invite')}
-                            />
-                        )}
-                    </View>
+                    {didScreenTransitionEnd && (
+                        <MemberInviteList
+                            inviteUsers={inviteUsers}
+                            excludedUsers={excludedUsers}
+                            name={reportName}
+                            confirmButtonText={translate('common.invite')}
+                        />
+                    )}
                 </FullPageNotFoundView>
             )}
         </ScreenWrapper>

--- a/src/pages/RoomInvitePage.js
+++ b/src/pages/RoomInvitePage.js
@@ -1,6 +1,7 @@
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, {useCallback, useMemo} from 'react';
+import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
@@ -8,6 +9,7 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MemberInviteList from '@components/MemberInviteList';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
 import compose from '@libs/compose';
 import Navigation from '@libs/Navigation/Navigation';
 import * as OptionsListUtils from '@libs/OptionsListUtils';
@@ -49,6 +51,7 @@ const defaultProps = {
 };
 
 function RoomInvitePage(props) {
+    const styles = useThemeStyles();
     const {translate} = useLocalize();
 
     const validate = useCallback((selectedUsersSize) => {
@@ -113,13 +116,17 @@ function RoomInvitePage(props) {
                             Navigation.goBack(backRoute);
                         }}
                     />
-                    <MemberInviteList
-                        didScreenTransitionEnd={didScreenTransitionEnd}
-                        inviteUsers={inviteUsers}
-                        excludedUsers={excludedUsers}
-                        name={reportName}
-                        confirmButtonText={translate('common.invite')}
-                    />
+                    <View style={[styles.flex1]}>
+                        {didScreenTransitionEnd && (
+                            <MemberInviteList
+                                didScreenTransitionEnd={didScreenTransitionEnd}
+                                inviteUsers={inviteUsers}
+                                excludedUsers={excludedUsers}
+                                name={reportName}
+                                confirmButtonText={translate('common.invite')}
+                            />
+                        )}
+                    </View>
                 </FullPageNotFoundView>
             )}
         </ScreenWrapper>

--- a/src/pages/RoomInvitePage.js
+++ b/src/pages/RoomInvitePage.js
@@ -119,7 +119,6 @@ function RoomInvitePage(props) {
                     <View style={[styles.flex1]}>
                         {didScreenTransitionEnd && (
                             <MemberInviteList
-                                didScreenTransitionEnd={didScreenTransitionEnd}
                                 inviteUsers={inviteUsers}
                                 excludedUsers={excludedUsers}
                                 name={reportName}

--- a/src/pages/RoomInvitePage.js
+++ b/src/pages/RoomInvitePage.js
@@ -1,7 +1,6 @@
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, {useCallback, useMemo} from 'react';
-import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
@@ -93,14 +92,13 @@ function RoomInvitePage(props) {
                             Navigation.goBack(backRoute);
                         }}
                     />
-                    {didScreenTransitionEnd && (
-                        <MemberInviteList
-                            inviteUsers={inviteUsers}
-                            excludedUsers={excludedUsers}
-                            name={reportName}
-                            confirmButtonText={translate('common.invite')}
-                        />
-                    )}
+                    <MemberInviteList
+                        inviteUsers={inviteUsers}
+                        excludedUsers={excludedUsers}
+                        name={reportName}
+                        confirmButtonText={translate('common.invite')}
+                        showLoadingPlaceholder={!didScreenTransitionEnd}
+                    />
                 </FullPageNotFoundView>
             )}
         </ScreenWrapper>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -10,7 +10,6 @@ import MemberInviteList from '@components/MemberInviteList';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
-import useThemeStyles from '@hooks/useThemeStyles';
 import compose from '@libs/compose';
 import Navigation from '@libs/Navigation/Navigation';
 import * as PolicyUtils from '@libs/PolicyUtils';
@@ -57,7 +56,6 @@ const defaultProps = {
 };
 
 function WorkspaceInvitePage(props) {
-    const styles = useThemeStyles();
     const {translate} = useLocalize();
     const openWorkspaceInvitePage = () => {
         const policyMemberEmailsToAccountIDs = PolicyUtils.getMemberAccountIDsForWorkspace(props.policyMembers, props.personalDetails);
@@ -128,17 +126,15 @@ function WorkspaceInvitePage(props) {
                             Navigation.goBack(ROUTES.WORKSPACE_MEMBERS.getRoute(props.route.params.policyID));
                         }}
                     />
-                    <View style={[styles.flex1]}>
-                        {didScreenTransitionEnd && (
-                            <MemberInviteList
-                                inviteUsers={inviteUsers}
-                                excludedUsers={excludedUsers}
-                                name={policyName}
-                                confirmButtonText={translate('common.next')}
-                                shouldShowAlertPrompt={shouldShowAlertPrompt}
-                            />
-                        )}
-                    </View>
+                    {didScreenTransitionEnd && (
+                        <MemberInviteList
+                            inviteUsers={inviteUsers}
+                            excludedUsers={excludedUsers}
+                            name={policyName}
+                            confirmButtonText={translate('common.next')}
+                            shouldShowAlertPrompt={shouldShowAlertPrompt}
+                        />
+                    )}
                 </FullPageNotFoundView>
             )}
         </ScreenWrapper>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -72,31 +72,8 @@ function WorkspaceInvitePage(props) {
 
     const excludedUsers = useMemo(() => PolicyUtils.getIneligibleInvitees(props.policyMembers, props.personalDetails), [props.policyMembers, props.personalDetails]);
 
-    const validate = (selectedMembersSize) => {
-        const errors = {};
-        if (selectedMembersSize <= 0) {
-            errors.noUserSelected = true;
-        }
-
-        Policy.setWorkspaceErrors(props.route.params.policyID, errors);
-        return _.size(errors) <= 0;
-    };
-
-    const inviteUsers = (selectedUsers) => {
-        if (!validate(selectedUsers.length)) {
-            return;
-        }
-
-        const invitedEmailsToAccountIDs = {};
-        _.each(selectedUsers, (option) => {
-            const login = option.login || '';
-            const accountID = lodashGet(option, 'accountID', '');
-            if (!login.toLowerCase().trim() || !accountID) {
-                return;
-            }
-            invitedEmailsToAccountIDs[login] = Number(accountID);
-        });
-        Policy.setWorkspaceInviteMembersDraft(props.route.params.policyID, invitedEmailsToAccountIDs);
+    const inviteUsers = (selectedEmailsToAccountIDs) => {
+        Policy.setWorkspaceInviteMembersDraft(props.route.params.policyID, selectedEmailsToAccountIDs);
         Navigation.navigate(ROUTES.WORKSPACE_INVITE_MESSAGE.getRoute(props.route.params.policyID));
     };
 

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -1,7 +1,6 @@
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, {useEffect, useMemo} from 'react';
-import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
@@ -103,15 +102,14 @@ function WorkspaceInvitePage(props) {
                             Navigation.goBack(ROUTES.WORKSPACE_MEMBERS.getRoute(props.route.params.policyID));
                         }}
                     />
-                    {didScreenTransitionEnd && (
-                        <MemberInviteList
-                            inviteUsers={inviteUsers}
-                            excludedUsers={excludedUsers}
-                            name={policyName}
-                            confirmButtonText={translate('common.next')}
-                            shouldShowAlertPrompt={shouldShowAlertPrompt}
-                        />
-                    )}
+                    <MemberInviteList
+                        inviteUsers={inviteUsers}
+                        excludedUsers={excludedUsers}
+                        name={policyName}
+                        confirmButtonText={translate('common.next')}
+                        shouldShowAlertPrompt={shouldShowAlertPrompt}
+                        showLoadingPlaceholder={!didScreenTransitionEnd}
+                    />
                 </FullPageNotFoundView>
             )}
         </ScreenWrapper>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -1,6 +1,7 @@
 import lodashGet from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, {useEffect, useMemo} from 'react';
+import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
@@ -9,6 +10,7 @@ import MemberInviteList from '@components/MemberInviteList';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
+import useThemeStyles from '@hooks/useThemeStyles';
 import compose from '@libs/compose';
 import Navigation from '@libs/Navigation/Navigation';
 import * as PolicyUtils from '@libs/PolicyUtils';
@@ -55,6 +57,7 @@ const defaultProps = {
 };
 
 function WorkspaceInvitePage(props) {
+    const styles = useThemeStyles();
     const {translate} = useLocalize();
     const openWorkspaceInvitePage = () => {
         const policyMemberEmailsToAccountIDs = PolicyUtils.getMemberAccountIDsForWorkspace(props.policyMembers, props.personalDetails);
@@ -125,14 +128,17 @@ function WorkspaceInvitePage(props) {
                             Navigation.goBack(ROUTES.WORKSPACE_MEMBERS.getRoute(props.route.params.policyID));
                         }}
                     />
-                    <MemberInviteList
-                        didScreenTransitionEnd={didScreenTransitionEnd}
-                        inviteUsers={inviteUsers}
-                        excludedUsers={excludedUsers}
-                        name={policyName}
-                        confirmButtonText={translate('common.next')}
-                        shouldShowAlertProm={shouldShowAlertPrompt}
-                    />
+                    <View style={[styles.flex1]}>
+                        {didScreenTransitionEnd && (
+                            <MemberInviteList
+                                inviteUsers={inviteUsers}
+                                excludedUsers={excludedUsers}
+                                name={policyName}
+                                confirmButtonText={translate('common.next')}
+                                shouldShowAlertProm={shouldShowAlertPrompt}
+                            />
+                        )}
+                    </View>
                 </FullPageNotFoundView>
             )}
         </ScreenWrapper>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -135,7 +135,7 @@ function WorkspaceInvitePage(props) {
                                 excludedUsers={excludedUsers}
                                 name={policyName}
                                 confirmButtonText={translate('common.next')}
-                                shouldShowAlertPrompt
+                                shouldShowAlertPrompt={shouldShowAlertPrompt}
                             />
                         )}
                     </View>

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -135,7 +135,7 @@ function WorkspaceInvitePage(props) {
                                 excludedUsers={excludedUsers}
                                 name={policyName}
                                 confirmButtonText={translate('common.next')}
-                                shouldShowAlertProm={shouldShowAlertPrompt}
+                                shouldShowAlertPrompt
                             />
                         )}
                     </View>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
    - [ ] MacOS: Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [ ] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
